### PR TITLE
_timeshift function does not work with offset formatters

### DIFF
--- a/src/functions/src/test/java/org/apache/jmeter/functions/TestTimeShiftFunction.java
+++ b/src/functions/src/test/java/org/apache/jmeter/functions/TestTimeShiftFunction.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertThat;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
@@ -126,6 +127,22 @@ public class TestTimeShiftFunction extends JMeterTestCase {
         LocalDateTime baseDate = LocalDateTime.parse("2017-12-21 12:00:00", dateFormat);
         LocalDateTime futureDate = baseDate.plusDays(10).plusHours(-1).plusMinutes(-5).plusSeconds(5);
         assertThat(futureDateFromFunction, within(1, ChronoUnit.SECONDS, futureDate));
+    }
+
+    @Test
+    void testShiftWithTimeZone() throws Exception {
+        String pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+        String timeString = "2017-12-21T12:00:00.000+0100";
+        Collection<CompoundVariable> params = makeParams(pattern, timeString, "P10DT-1H-5M5S", "");
+        function.setParameters(params);
+        value = function.execute(result, null);
+        ZonedDateTime futureDateFromFunction = ZonedDateTime.parse(value, DateTimeFormatter.ofPattern(pattern));
+
+        DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern(pattern);
+        LocalDateTime baseDate = ZonedDateTime.parse(timeString, dateFormat).toLocalDateTime();
+        LocalDateTime futureDate = baseDate.plusDays(10).plusHours(-1).plusMinutes(-5).plusSeconds(5);
+        assertThat(futureDateFromFunction.toLocalDateTime(), within(1, ChronoUnit.SECONDS, futureDate));
+
     }
 
     public static void main(String[] args) {

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -103,6 +103,7 @@ to view the last release notes of version 5.2.1.
 
 <h3>Functions</h3>
 <ul>
+  <li><bug>64070</bug><code>_timeshift</code> function does not work with offset formatters</li>
 </ul>
 
 <h3>I18N</h3>
@@ -187,6 +188,7 @@ to view the last release notes of version 5.2.1.
 <ul>
   <li>Michael McDermott (mcdermott.michaelj at gmail.com)</li>
   <li>yangxiaofei77 (yangxiaofei77 at gmail.com)</li>
+  <li>Markus Wolf (wolfm at t-systems.com)</li>
 </ul>
 <p>
 Apologies if we have omitted anyone else.


### PR DESCRIPTION
Bugzilla Id: 64070

## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
